### PR TITLE
Fixes encoding: generate cosine instead of sine

### DIFF
--- a/dist/webjack.js
+++ b/dist/webjack.js
@@ -364,8 +364,8 @@ WebJack.Encoder = Class.extend({
 			var phaseIncHigh = 2 * Math.PI * freqHigh / sampleRate;
 			
 			for (var i=0; i < samplesPerBit; i++) {
-				bitBufferLow.set( [Math.sin(phaseIncLow*i)], i);
-				bitBufferHigh.set( [Math.sin(phaseIncHigh*i)], i);
+				bitBufferLow.set( [Math.cos(phaseIncLow*i)], i);
+				bitBufferHigh.set( [Math.cos(phaseIncHigh*i)], i);
 			}
 		})();
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,12 +34,14 @@
 
     jQuery(document).ready(function($) {
 
+      var log = $('.webjack-log');
+
       connection = new WebJack.Connection({baud: 1225});
 
       connection.listen(function(data) {
-        var log = $('.webjack-log');
         log.append(data);
         log.append('<br>');
+        log.scrollTop(log[0].scrollHeight);
         console.log('Arduino to WebJack: ' + data);
       });
 

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -31,8 +31,8 @@ WebJack.Encoder = Class.extend({
 			var phaseIncHigh = 2 * Math.PI * freqHigh / sampleRate;
 			
 			for (var i=0; i < samplesPerBit; i++) {
-				bitBufferLow.set( [Math.sin(phaseIncLow*i)], i);
-				bitBufferHigh.set( [Math.sin(phaseIncHigh*i)], i);
+				bitBufferLow.set( [Math.cos(phaseIncLow*i)], i);
+				bitBufferHigh.set( [Math.cos(phaseIncHigh*i)], i);
 			}
 		})();
 


### PR DESCRIPTION
The circuit (highpass) derivates the generated signal → cosine becomes negative sine at receiver. The receiver (Arduino) expects a negative sine.
Interesting that it worked before, although not very well.

Also: autoscroll for the demo site.